### PR TITLE
Temporarily defaulting to advanced indexing.

### DIFF
--- a/src/FairPlayTubeSln/FairPlayTube.Controllers/AzureVideoIndexerController.cs
+++ b/src/FairPlayTubeSln/FairPlayTube.Controllers/AzureVideoIndexerController.cs
@@ -53,12 +53,12 @@ namespace FairPlayTube.Controllers
                 if (videoInfoEntity != null)
                 {
                     var videoIndex = await VideoService.GetVideoIndexerStatus(id, cancellationToken);
+                    await VideoService.SaveIndexedVideoKeywordsAsync(id, cancellationToken);
+                    await VideoService.SaveVideoThumbnailAsync(id, videoIndex.videos.First().thumbnailId, cancellationToken);
                     videoInfoEntity.VideoIndexStatusId = (int)Common.Global.Enums.VideoIndexStatus.Processed;
                     videoInfoEntity.VideoIndexSourceClass = this.GetType().FullName;
                     videoInfoEntity.VideoDurationInSeconds = videoIndex.summarizedInsights.duration.seconds;
                     await this.FairplaytubeDatabaseContext.SaveChangesAsync();
-                    await VideoService.SaveIndexedVideoKeywordsAsync(id, cancellationToken);
-                    await VideoService.SaveVideoThumbnailAsync(id, videoIndex.videos.First().thumbnailId, cancellationToken);
                 }
             }
         }

--- a/src/FairPlayTubeSln/FairPlayTube.Services/FairPlayTube.Services.csproj
+++ b/src/FairPlayTubeSln/FairPlayTube.Services/FairPlayTube.Services.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="PTI.Microservices.Library.AzureBlobStorage" Version="2.0.0.2-preview" />
     <PackageReference Include="PTI.Microservices.Library.AzureContentModerator" Version="2.0.0.1-preview" />
     <PackageReference Include="PTI.Microservices.Library.AzureTextAnalytics" Version="2.0.0.1-preview" />
-    <PackageReference Include="PTI.Microservices.Library.AzureVideoIndexer" Version="2.0.0.2-preview" />
+    <PackageReference Include="PTI.Microservices.Library.AzureVideoIndexer" Version="2.0.0.3-preview" />
     <PackageReference Include="PTI.Microservices.Library.IpStack" Version="2.0.0-preview" />
     <PackageReference Include="PTI.Microservices.Library.PayPal" Version="2.0.0.1-preview" />
   </ItemGroup>


### PR DESCRIPTION
Moved code to mark videos as processed until the rest of the data is set.

### Checklist

- [ ] Created/Updated Automated Test(s) for the related controller(s)
- [ ] Verified all Automated Tests are passing locally.
- [ ] Added reviewer(s)
- [x] Referenced the related Issue/Task


### Description
Temporarily set indexing preset to Advanced.
Moved logic of setting videos as processed until after the thumbnails have been retrieved

## Related Issue
Solves Github Issue #275 
